### PR TITLE
Add max_order_count to GenerationService

### DIFF
--- a/order/include/order/generation_service.hpp
+++ b/order/include/order/generation_service.hpp
@@ -24,15 +24,19 @@
 #include "tcp/connection.hpp"
 #include "tcp/server.hpp"
 #include <memory>
+#include <mutex>
 
 namespace order {
 class GenerationService {
     tcp::Server server;
     std::shared_ptr<Generator> generator;
     void parse_message(std::shared_ptr<tcp::Connection> connection);
+    int max_order_count;
+    int order_count = 0;
+    std::mutex order_count_mutex;
 
   public:
-    GenerationService(int port, std::shared_ptr<Generator> generator);
+    GenerationService(int port, std::shared_ptr<Generator> generator, int max_order_count = -1);
     void start();
     int get_port();
 };

--- a/order/src/generation_service.cpp
+++ b/order/src/generation_service.cpp
@@ -42,7 +42,6 @@ void GenerationService::parse_message(std::shared_ptr<tcp::Connection> connectio
 
         if (max_order_count > -1 && order_count >= max_order_count) {
             connection->send("no_orders");
-            lock.unlock();
             return;
         }
 

--- a/order/src/generation_service.cpp
+++ b/order/src/generation_service.cpp
@@ -20,11 +20,13 @@
 #include "order/generation_service.hpp"
 #include <iostream>
 #include <memory>
+#include <mutex>
 #include <thread>
 
 namespace order {
-GenerationService::GenerationService(int port, std::shared_ptr<Generator> generator)
-    : server(port), generator(generator){};
+GenerationService::GenerationService(int port, std::shared_ptr<Generator> generator,
+                                     int max_order_count)
+    : server(port), generator(generator), max_order_count(max_order_count){};
 
 int GenerationService::get_port()
 {
@@ -36,6 +38,17 @@ void GenerationService::parse_message(std::shared_ptr<tcp::Connection> connectio
     std::string message = connection->receive_blocking();
 
     if (message == "get_order") {
+        std::unique_lock<std::mutex> lock{order_count_mutex};
+
+        if (max_order_count > -1 && order_count >= max_order_count) {
+            connection->send("no_orders");
+            lock.unlock();
+            return;
+        }
+
+        order_count++;
+        lock.unlock();
+
         Order order = generator->generate_order();
         std::cout << "Giving order: " << order.to_json().toStyledString() << std::endl;
         connection->send(order.to_json().toStyledString());

--- a/order/src/order_generation_service.cpp
+++ b/order/src/order_generation_service.cpp
@@ -67,7 +67,7 @@ int main(int argc, char *argv[])
         {"help", no_argument, 0, 'h'},           {"port", required_argument, 0, 'p'},
         {"count", required_argument, 0, 'c'}};
 
-    const std::string short_options{"s:n:m:r::p:h"};
+    const std::string short_options{"s:n:m:r::p:c:h"};
 
     int argument_index = 0;
     int port = 7777;

--- a/order/src/order_generation_service.cpp
+++ b/order/src/order_generation_service.cpp
@@ -73,7 +73,7 @@ int main(int argc, char *argv[])
     int port = 7777;
     int min_size;
     int max_size;
-    int count;
+    int count = 0;
     unsigned seed;
     std::vector<int> stations;
     std::string generator_type;

--- a/order/src/order_generation_service.cpp
+++ b/order/src/order_generation_service.cpp
@@ -34,7 +34,8 @@ void print_help()
            "--random=<seed>                 Uses a random order generator with an optional seed\n"
            "--min=<size>                    Minimum order size (used with random generator)\n"
            "--max=<size>                    Maxmum order size (used with random generator)\n"
-           "--port=<port>                   Sets the port of the server\n";
+           "--port=<port>                   Sets the port of the server\n"
+           "--count=<count>                 Sets the maximum number of orders to be generated\n";
     exit(1);
 }
 
@@ -63,7 +64,8 @@ int main(int argc, char *argv[])
     const option options[] = {
         {"stations", required_argument, 0, 's'}, {"random", optional_argument, 0, 'r'},
         {"min", required_argument, 0, 'n'},      {"max", required_argument, 0, 'm'},
-        {"help", no_argument, 0, 'h'},           {"port", required_argument, 0, 'p'}};
+        {"help", no_argument, 0, 'h'},           {"port", required_argument, 0, 'p'},
+        {"count", required_argument, 0, 'c'}};
 
     const std::string short_options{"s:n:m:r::p:h"};
 
@@ -71,6 +73,7 @@ int main(int argc, char *argv[])
     int port = 7777;
     int min_size;
     int max_size;
+    int count;
     unsigned seed;
     std::vector<int> stations;
     std::string generator_type;
@@ -100,6 +103,9 @@ int main(int argc, char *argv[])
             break;
         case 'p':
             port = atoi(optarg);
+            break;
+        case 'c':
+            count = atoi(optarg);
             break;
         case 'h':
         default:
@@ -132,13 +138,13 @@ int main(int argc, char *argv[])
                   << std::static_pointer_cast<RandomGenerator>(generator)->get_max_size()
                   << std::endl;
     }
-    // TODO: Handle other generators.
     else {
         std::cerr << "Generator type not set" << std::endl;
         exit(1);
     }
 
-    GenerationService service = GenerationService{port, generator};
+    GenerationService service =
+        !count ? GenerationService{port, generator} : GenerationService{port, generator, count};
 
     std::cout << "Starting on port " << service.get_port() << std::endl;
 

--- a/order/src/order_generation_service.cpp
+++ b/order/src/order_generation_service.cpp
@@ -144,7 +144,7 @@ int main(int argc, char *argv[])
     }
 
     GenerationService service =
-        !count ? GenerationService{port, generator} : GenerationService{port, generator, count};
+        count == 0 ? GenerationService{port, generator} : GenerationService{port, generator, count};
 
     std::cout << "Starting on port " << service.get_port() << std::endl;
 


### PR DESCRIPTION
Det er nu muligt at sende et `--count`/`-c` parameter med til `order_generation_service`, der dikterer, hvor mange ordrer, der bliver genereret. Når der er blevet genereret `--count` orderer, svarer serveren med en `no_order`-beksed.